### PR TITLE
use project path's dirname as project Name if name is blank

### DIFF
--- a/unity-launcher/Form1.cs
+++ b/unity-launcher/Form1.cs
@@ -165,9 +165,14 @@ namespace unity_launcher
             try {
                 var path = pathToAssets.Substring(0, pathToAssets.Length - "\\Assets".Length);
                 var version = File.ReadAllText(path + "\\ProjectSettings\\ProjectVersion.txt").Replace("m_EditorVersion: ", "").Trim();
+                var name = path.Replace(removePrefixInPath, "").Trim().Trim('\\', '/');
+                if(name.Length == 0) {
+                    name = Path.GetFileName(path);
+                }
+
                 return new Project() {
                     Path = path,
-                    Name = path.Replace(removePrefixInPath, "").Trim().Trim('\\', '/'),
+                    Name = name,
                     UnityVersion = version,
                 };
             }


### PR DESCRIPTION
example config file
```
5.5.0f3
C:\Program Files\Unity-5.5.0f3\Editor\Unity.exe
---
C:\devel\tc\capture-the-base\CaptureTheBase_Android
```
example project path : `C:\devel\tc\capture-the-base\CaptureTheBase_Android`. `C:\devel\tc\capture-the-base\CaptureTheBase_Android\Assets` exists.

If project root equals project path, project has blank name. It looks like bug.
So, I modify code. If name is blank, use project path's dirname as name.

before
![unity-launcher](https://user-images.githubusercontent.com/971476/28710231-36480b4c-73be-11e7-83d5-a0843c7ddd5b.png)

after
![unity-launcher-after](https://user-images.githubusercontent.com/971476/28710257-4e5c60fc-73be-11e7-9573-4a7db05f780d.png)
project path is `C:\devel\tc\capture-the-base\CaptureTheBase_Android`, use `CaptureTheBase_Android` as project name.


